### PR TITLE
feat(themes): add auto-theming support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ luac.out
 # Temporary files
 *.tmp
 *.temp
+
+CLAUDE.md

--- a/docs/plans/2026-01-29-auto-theming-design.md
+++ b/docs/plans/2026-01-29-auto-theming-design.md
@@ -1,0 +1,172 @@
+# Auto-Theming Design
+
+## Overview
+
+Automatically generate a luxline theme by extracting colors from the active Neovim colorscheme's highlight groups. No pre-defined theme mappings - pure auto-detection with caching.
+
+## Theme Structure
+
+New format with per-position foregrounds:
+
+```lua
+{
+    gradient = {
+        { bg = '#0f0f23', fg = '#e0e7ff' },  -- position 1
+        { bg = '#1a1a2e', fg = '#e0e7ff' },  -- position 2
+        { bg = '#2A305E', fg = '#e0e7ff' },  -- position 3
+        { bg = '#4a3674', fg = '#e0e7ff' },  -- position 4
+        { bg = '#7c3aed', fg = '#ffffff' },  -- position 5
+        { bg = '#8b5cf6', fg = '#ffffff' },  -- position 6
+        { bg = '#a855f7', fg = '#1a1a1a' },  -- position 7
+    },
+    middle = '#1a1a2e',
+    semantic = {
+        LuxlineFilename = { fg = '...', bg = '...' },
+        LuxlineGit = { fg = '...', bg = '...' },
+        -- etc.
+    }
+}
+```
+
+**Removed fields**: `foreground`, `fallback` - no longer needed since each gradient position has its own fg.
+
+## Gradient Extraction
+
+### Highlight Group → Gradient Position Mapping
+
+| Position | Primary Source | Fallback Chain |
+|----------|----------------|----------------|
+| 1 | `Normal.bg` | `StatusLine.bg` → `#1a1a1a` |
+| 2 | `CursorLine.bg` | `StatusLineNC.bg` → position 1 |
+| 3 | `Visual.bg` | `Pmenu.bg` → position 2 |
+| 4 | `StatusLine.bg` | `Normal.bg` → position 3 |
+| 5 | `Search.bg` | `WildMenu.bg` → position 4 |
+| 6 | `IncSearch.bg` | `Substitute.bg` → position 5 |
+| 7 | `Cursor.bg` | `Title.fg` → `MatchParen.bg` |
+
+### Extraction Function
+
+```lua
+local function get_hl_colors(group)
+    local hl = vim.api.nvim_get_hl(0, { name = group, link = false })
+    return {
+        bg = hl.bg and string.format('#%06x', hl.bg) or nil,
+        fg = hl.fg and string.format('#%06x', hl.fg) or nil,
+    }
+end
+```
+
+### Fallback Logic
+
+For each position, try primary source. If `bg` is nil, try each fallback in order. If all fail, use the previous position's color (positions 2-7) or a hardcoded dark/light default (position 1).
+
+**Foreground**: Extract `fg` from the same highlight group that provided the `bg`. If nil, use `Normal.fg`.
+
+## Semantic Highlight Mapping
+
+| Semantic Highlight | Primary Source | Fallback |
+|--------------------|----------------|----------|
+| `LuxlineFilename` | `Title` | gradient position 5 |
+| `LuxlineWinbarFilename` | `Title` | gradient position 4 |
+| `LuxlineModified` | `DiagnosticWarn` | `WarningMsg` |
+| `LuxlineWinbarModified` | `DiagnosticWarn` | `WarningMsg` |
+| `LuxlineGit` | `GitSignsAdd` | `DiffAdd` → `String` |
+| `LuxlineWinbarGit` | `GitSignsAdd` | `DiffAdd` → `String` |
+| `LuxlinePosition` | `StatusLine` | gradient position 5 |
+| `LuxlineWinbarPosition` | `WinBar` | gradient position 4 |
+| `LuxlinePercent` | `Search` | gradient position 6 |
+| `LuxlineWinbarPercent` | `IncSearch` | gradient position 5 |
+| `LuxlineWindownumber` | `Title` | gradient position 3 |
+| `LuxlineWinbarWindownumber` | `WinBar` | gradient position 2 |
+| `LuxlineSpacer` | `StatusLine` | gradient position 2 |
+| `LuxlineWinbarSpacer` | `WinBar` | gradient position 2 |
+
+Bold is added to `Modified` and `Windownumber` items.
+
+## Caching
+
+- Cache stored in memory keyed by `vim.g.colors_name`
+- Invalidated on `ColorScheme` autocmd when the name changes
+- Structure: `local theme_cache = {}  -- { [colorscheme_name] = generated_theme }`
+
+## Integration
+
+### New Module: `lua/luxline/themes/auto.lua`
+
+```lua
+local M = {}
+
+M.generate(colorscheme_name)  -- Returns theme or nil
+M.invalidate(colorscheme_name)  -- Clears cache entry
+M.invalidate_all()  -- Clears entire cache
+
+return M
+```
+
+### Modified Flow in `themes/init.lua`
+
+```lua
+function M.set_theme(theme_name)
+    theme_name = theme_name or vim.g.colors_name or 'default'
+
+    local theme = M.get_theme(theme_name)
+
+    if not theme then
+        -- Try auto-generation
+        local auto = require('luxline.themes.auto')
+        theme = auto.generate(vim.g.colors_name)
+    end
+
+    if not theme then
+        -- Final fallback to default
+        theme = M.get_theme('default')
+    end
+
+    -- ... rest unchanged
+end
+```
+
+### ColorScheme Autocmd
+
+```lua
+events.on('colorscheme_changed', function()
+    local auto = require('luxline.themes.auto')
+    auto.invalidate(vim.g.colors_name)
+    M.set_theme(vim.g.colors_name)
+end)
+```
+
+## File Changes
+
+### New File
+- `lua/luxline/themes/auto.lua` - Color extraction and theme generation
+
+### Modified Files
+- `lua/luxline/themes/init.lua` - Integrate auto-generation fallback
+- `lua/luxline/themes/data/lux-themes.lua` - Migrate to new format
+- `lua/luxline/themes/default.lua` - Migrate to new format
+- `lua/luxline/themes/validation.lua` - Validate new structure only
+- `lua/luxline/rendering/highlight.lua` - Use per-position fg/bg
+- `lua/luxline/rendering/bar_builder.lua` - Update gradient access
+
+## Migration
+
+Full migration to new format. No backwards compatibility with old format.
+
+All existing themes in `lux-themes.lua` will be converted to:
+
+```lua
+['lux-vesper'] = {
+    gradient = {
+        { bg = '#0f0f23', fg = '#e0e7ff' },
+        { bg = '#1a1a2e', fg = '#e0e7ff' },
+        { bg = '#2A305E', fg = '#e0e7ff' },
+        { bg = '#4a3674', fg = '#e0e7ff' },
+        { bg = '#7c3aed', fg = '#ffffff' },
+        { bg = '#8b5cf6', fg = '#ffffff' },
+        { bg = '#a855f7', fg = '#1a1a1a' },
+    },
+    middle = '#1a1a2e',
+    semantic = { ... }
+}
+```

--- a/docs/plans/2026-01-29-auto-theming.md
+++ b/docs/plans/2026-01-29-auto-theming.md
@@ -1,0 +1,650 @@
+# Auto-Theming Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Automatically generate luxline themes by extracting colors from any Neovim colorscheme's highlight groups.
+
+**Architecture:** New `themes/auto.lua` module extracts colors from highlight groups, builds gradient with per-position fg/bg, generates semantic highlights, and caches by colorscheme name. Full migration to new theme format - no backwards compatibility.
+
+**Tech Stack:** Lua, Neovim API (`nvim_get_hl`)
+
+---
+
+### Task 1: Create auto.lua - Color Extraction
+
+**Files:**
+- Create: `lua/luxline/themes/auto.lua`
+
+**Step 1: Create the module with extraction helper**
+
+```lua
+local M = {}
+
+local theme_cache = {}
+
+local function get_hl_colors(group)
+    local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
+    if not ok or not hl then
+        return { bg = nil, fg = nil }
+    end
+    return {
+        bg = hl.bg and string.format('#%06x', hl.bg) or nil,
+        fg = hl.fg and string.format('#%06x', hl.fg) or nil,
+    }
+end
+
+local function get_color_with_fallbacks(primary, fallbacks, attr, default)
+    local colors = get_hl_colors(primary)
+    if colors[attr] then
+        return colors
+    end
+
+    for _, fallback in ipairs(fallbacks or {}) do
+        colors = get_hl_colors(fallback)
+        if colors[attr] then
+            return colors
+        end
+    end
+
+    return { bg = default, fg = default }
+end
+
+return M
+```
+
+**Step 2: Verify module loads**
+
+Run in Neovim: `:lua print(vim.inspect(require('luxline.themes.auto')))`
+Expected: Table with empty functions
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/themes/auto.lua
+git commit -m "feat(themes): add auto.lua with color extraction helpers"
+```
+
+---
+
+### Task 2: Implement Gradient Generation
+
+**Files:**
+- Modify: `lua/luxline/themes/auto.lua`
+
+**Step 1: Add gradient position mapping**
+
+```lua
+local GRADIENT_MAPPING = {
+    { primary = 'Normal', fallbacks = { 'StatusLine' }, attr = 'bg', default = '#1a1a1a' },
+    { primary = 'CursorLine', fallbacks = { 'StatusLineNC' }, attr = 'bg', default = nil },
+    { primary = 'Visual', fallbacks = { 'Pmenu' }, attr = 'bg', default = nil },
+    { primary = 'StatusLine', fallbacks = { 'Normal' }, attr = 'bg', default = nil },
+    { primary = 'Search', fallbacks = { 'WildMenu' }, attr = 'bg', default = nil },
+    { primary = 'IncSearch', fallbacks = { 'Substitute' }, attr = 'bg', default = nil },
+    { primary = 'Cursor', fallbacks = { 'Title', 'MatchParen' }, attr = 'bg', default = nil },
+}
+
+local function build_gradient()
+    local gradient = {}
+    local normal_fg = get_hl_colors('Normal').fg or '#d0d0d0'
+
+    for i, mapping in ipairs(GRADIENT_MAPPING) do
+        local colors = get_color_with_fallbacks(mapping.primary, mapping.fallbacks, mapping.attr, mapping.default)
+        local bg = colors.bg
+        local fg = colors.fg or normal_fg
+
+        if not bg and i > 1 then
+            bg = gradient[i - 1].bg
+        end
+
+        if not bg then
+            bg = mapping.default or '#1a1a1a'
+        end
+
+        gradient[i] = { bg = bg, fg = fg }
+    end
+
+    return gradient
+end
+```
+
+**Step 2: Verify gradient builds**
+
+Run in Neovim:
+```lua
+:lua local auto = require('luxline.themes.auto'); print(vim.inspect(auto._build_gradient()))
+```
+Expected: Table with 7 entries, each having bg and fg
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/themes/auto.lua
+git commit -m "feat(themes): add gradient generation from highlight groups"
+```
+
+---
+
+### Task 3: Implement Semantic Highlight Generation
+
+**Files:**
+- Modify: `lua/luxline/themes/auto.lua`
+
+**Step 1: Add semantic mapping and generator**
+
+```lua
+local SEMANTIC_MAPPING = {
+    LuxlineFilename = { primary = 'Title', fallback_pos = 5 },
+    LuxlineWinbarFilename = { primary = 'Title', fallback_pos = 4 },
+    LuxlineModified = { primary = 'DiagnosticWarn', fallbacks = { 'WarningMsg' }, bold = true },
+    LuxlineWinbarModified = { primary = 'DiagnosticWarn', fallbacks = { 'WarningMsg' }, bold = true },
+    LuxlineGit = { primary = 'GitSignsAdd', fallbacks = { 'DiffAdd', 'String' } },
+    LuxlineWinbarGit = { primary = 'GitSignsAdd', fallbacks = { 'DiffAdd', 'String' } },
+    LuxlinePosition = { primary = 'StatusLine', fallback_pos = 5 },
+    LuxlineWinbarPosition = { primary = 'WinBar', fallback_pos = 4 },
+    LuxlinePercent = { primary = 'Search', fallback_pos = 6 },
+    LuxlineWinbarPercent = { primary = 'IncSearch', fallback_pos = 5 },
+    LuxlineWindownumber = { primary = 'Title', fallback_pos = 3, bold = true },
+    LuxlineWinbarWindownumber = { primary = 'WinBar', fallback_pos = 2, bold = true },
+    LuxlineSpacer = { primary = 'StatusLine', fallback_pos = 2 },
+    LuxlineWinbarSpacer = { primary = 'WinBar', fallback_pos = 2 },
+}
+
+local function build_semantic(gradient)
+    local semantic = {}
+
+    for group_name, mapping in pairs(SEMANTIC_MAPPING) do
+        local colors = get_color_with_fallbacks(mapping.primary, mapping.fallbacks, 'bg', nil)
+        local bg = colors.bg
+        local fg = colors.fg
+
+        if not bg and mapping.fallback_pos and gradient[mapping.fallback_pos] then
+            bg = gradient[mapping.fallback_pos].bg
+            fg = fg or gradient[mapping.fallback_pos].fg
+        end
+
+        if bg then
+            semantic[group_name] = {
+                bg = bg,
+                fg = fg or gradient[1].fg or '#d0d0d0',
+                bold = mapping.bold,
+            }
+        end
+    end
+
+    return semantic
+end
+```
+
+**Step 2: Verify semantic builds**
+
+Run in Neovim:
+```lua
+:lua local auto = require('luxline.themes.auto'); local g = auto._build_gradient(); print(vim.inspect(auto._build_semantic(g)))
+```
+Expected: Table with semantic highlight definitions
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/themes/auto.lua
+git commit -m "feat(themes): add semantic highlight generation"
+```
+
+---
+
+### Task 4: Implement Public API and Caching
+
+**Files:**
+- Modify: `lua/luxline/themes/auto.lua`
+
+**Step 1: Add public API functions**
+
+```lua
+function M.generate(colorscheme_name)
+    colorscheme_name = colorscheme_name or vim.g.colors_name or 'default'
+
+    if theme_cache[colorscheme_name] then
+        return theme_cache[colorscheme_name]
+    end
+
+    local gradient = build_gradient()
+    local semantic = build_semantic(gradient)
+
+    local theme = {
+        gradient = gradient,
+        middle = gradient[2].bg,
+        semantic = semantic,
+    }
+
+    theme_cache[colorscheme_name] = theme
+    return theme
+end
+
+function M.invalidate(colorscheme_name)
+    if colorscheme_name then
+        theme_cache[colorscheme_name] = nil
+    end
+end
+
+function M.invalidate_all()
+    theme_cache = {}
+end
+
+M._build_gradient = build_gradient
+M._build_semantic = build_semantic
+```
+
+**Step 2: Verify full generation**
+
+Run in Neovim:
+```lua
+:lua local auto = require('luxline.themes.auto'); print(vim.inspect(auto.generate()))
+```
+Expected: Complete theme table with gradient, middle, and semantic
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/themes/auto.lua
+git commit -m "feat(themes): add public API with caching"
+```
+
+---
+
+### Task 5: Migrate lux-themes.lua to New Format
+
+**Files:**
+- Modify: `lua/luxline/themes/data/lux-themes.lua`
+
+**Step 1: Convert nami theme**
+
+```lua
+['nami'] = {
+    gradient = {
+        { bg = '#0d1821', fg = '#e8dcc8' },
+        { bg = '#1a2734', fg = '#e8dcc8' },
+        { bg = '#2a3a4a', fg = '#e8dcc8' },
+        { bg = '#3a9ba8', fg = '#e8dcc8' },
+        { bg = '#4fc9c9', fg = '#0d1821' },
+        { bg = '#ff8c6b', fg = '#0d1821' },
+        { bg = '#ffd48c', fg = '#0d1821' },
+    },
+    middle = '#1a2734',
+    semantic = {
+        LuxlineFilename = { fg = '#e8dcc8', bg = '#4fc9c9' },
+        LuxlineWinbarFilename = { fg = '#e8dcc8', bg = '#3a9ba8' },
+        LuxlineModified = { fg = '#ffd48c', bg = '#ff6b4a', bold = true },
+        LuxlineWinbarModified = { fg = '#ffd48c', bg = '#ff6b4a', bold = true },
+        LuxlineGit = { fg = '#4fc9c9', bg = '#2a3a4a' },
+        LuxlineWinbarGit = { fg = '#4fc9c9', bg = '#1a2734' },
+        LuxlinePosition = { fg = '#e8dcc8', bg = '#ff8c6b' },
+        LuxlineWinbarPosition = { fg = '#e8dcc8', bg = '#3a9ba8' },
+        LuxlinePercent = { fg = '#0d1821', bg = '#ffd48c' },
+        LuxlineWinbarPercent = { fg = '#0d1821', bg = '#ffa857' },
+        LuxlineWindownumber = { fg = '#ffd48c', bg = '#2a3a4a', bold = true },
+        LuxlineWinbarWindownumber = { fg = '#ffd48c', bg = '#1a2734', bold = true },
+        LuxlineSpacer = { fg = '#1a2734', bg = '#1a2734' },
+        LuxlineWinbarSpacer = { fg = '#1a2734', bg = '#1a2734' },
+    },
+},
+```
+
+**Step 2: Convert lux-vesper theme**
+
+```lua
+['lux-vesper'] = {
+    gradient = {
+        { bg = '#0f0f23', fg = '#e0e7ff' },
+        { bg = '#1a1a2e', fg = '#e0e7ff' },
+        { bg = '#2A305E', fg = '#e0e7ff' },
+        { bg = '#4a3674', fg = '#e0e7ff' },
+        { bg = '#7c3aed', fg = '#ffffff' },
+        { bg = '#8b5cf6', fg = '#ffffff' },
+        { bg = '#a855f7', fg = '#1a1a1a' },
+    },
+    middle = '#1a1a2e',
+    semantic = {
+        LuxlineFilename = { fg = '#e0e7ff', bg = '#7c3aed' },
+        LuxlineWinbarFilename = { fg = '#e0e7ff', bg = '#6d28d9' },
+        LuxlineModified = { fg = '#fbbf24', bg = '#dc2626', bold = true },
+        LuxlineWinbarModified = { fg = '#fbbf24', bg = '#b91c1c', bold = true },
+        LuxlineGit = { fg = '#22c55e', bg = '#4a3674' },
+        LuxlineWinbarGit = { fg = '#22c55e', bg = '#3c2e60' },
+        LuxlinePosition = { fg = '#e0e7ff', bg = '#8b5cf6' },
+        LuxlineWinbarPosition = { fg = '#e0e7ff', bg = '#7c3aed' },
+        LuxlinePercent = { fg = '#e0e7ff', bg = '#a855f7' },
+        LuxlineWinbarPercent = { fg = '#e0e7ff', bg = '#9333ea' },
+        LuxlineWindownumber = { fg = '#fbbf24', bg = '#4a3674', bold = true },
+        LuxlineWinbarWindownumber = { fg = '#fbbf24', bg = '#3c2e60', bold = true },
+        LuxlineSpacer = { fg = '#1a1a2e', bg = '#1a1a2e' },
+        LuxlineWinbarSpacer = { fg = '#1a1a2e', bg = '#1a1a2e' },
+    },
+},
+```
+
+**Step 3: Convert remaining themes (lux-aurora, lux-chroma, lux-eos, lux-umbra)**
+
+Each needs gradient converted from array of strings to array of {bg, fg} objects. For themes without semantic, generate basic semantic from gradient positions.
+
+**Step 4: Commit**
+
+```bash
+git add lua/luxline/themes/data/lux-themes.lua
+git commit -m "feat(themes): migrate lux-themes.lua to new format"
+```
+
+---
+
+### Task 6: Update validation.lua for New Format
+
+**Files:**
+- Modify: `lua/luxline/themes/validation.lua`
+
+**Step 1: Update DEFAULT_THEME and get_default_theme**
+
+```lua
+M.DEFAULT_THEME = {
+    gradient = {},
+    middle = '#1a1a2e',
+}
+
+function M.get_default_theme()
+    local default = vim.deepcopy(M.DEFAULT_THEME)
+    local normal_fg = '#d0d0d0'
+
+    for i = 1, 7 do
+        local gray_value = math.floor(0x40 + (i - 1) * 0x10)
+        local bg = string.format('#%02x%02x%02x', gray_value, gray_value, gray_value)
+        default.gradient[i] = { bg = bg, fg = normal_fg }
+    end
+
+    default.middle = default.gradient[2].bg
+    return default
+end
+```
+
+**Step 2: Update validate_theme function**
+
+```lua
+function M.validate_theme(theme, name)
+    if type(theme) ~= 'table' then
+        vim.notify('Theme must be a table: ' .. (name or 'unknown'), vim.log.levels.WARN)
+        return M.get_default_theme()
+    end
+
+    local validated = utils.deep_merge(M.get_default_theme(), theme)
+
+    if not validated.gradient or #validated.gradient ~= 7 then
+        if name then
+            vim.notify('Theme gradient must have exactly 7 colors: ' .. name, vim.log.levels.WARN)
+        end
+        validated = M.get_default_theme()
+    end
+
+    for i, entry in ipairs(validated.gradient) do
+        if type(entry) ~= 'table' or not entry.bg then
+            vim.notify('Invalid gradient entry at position ' .. i, vim.log.levels.WARN)
+            validated.gradient[i] = { bg = '#808080', fg = '#d0d0d0' }
+        end
+    end
+
+    return validated
+end
+```
+
+**Step 3: Update validate_gradient function**
+
+```lua
+function M.validate_gradient(gradient)
+    if type(gradient) ~= 'table' then
+        return false, 'Gradient must be a table'
+    end
+
+    if #gradient ~= 7 then
+        return false, 'Gradient must have exactly 7 entries'
+    end
+
+    for i, entry in ipairs(gradient) do
+        if type(entry) ~= 'table' then
+            return false, 'Gradient entry ' .. i .. ' must be a table'
+        end
+        if not M.validate_color(entry.bg) then
+            return false, 'Invalid bg color at position ' .. i
+        end
+        if entry.fg and not M.validate_color(entry.fg) then
+            return false, 'Invalid fg color at position ' .. i
+        end
+    end
+
+    return true
+end
+```
+
+**Step 4: Remove legacy itemLeft/Right generation from validate_theme**
+
+Delete lines 53-57 that generate legacy `itemLeft1`, `itemRight1`, etc.
+
+**Step 5: Commit**
+
+```bash
+git add lua/luxline/themes/validation.lua
+git commit -m "feat(themes): update validation for new gradient format"
+```
+
+---
+
+### Task 7: Update highlight_strategies.lua for Per-Position Foreground
+
+**Files:**
+- Modify: `lua/luxline/rendering/highlight_strategies.lua`
+
+**Step 1: Update positional strategy create_highlight**
+
+```lua
+create_highlight = function(group_name, side, idx, bar_type)
+    local themes = require('luxline.themes')
+    local theme = themes.get_current_theme()
+
+    if not theme or not theme.gradient then
+        return nil
+    end
+
+    local gradient_idx = math.min(idx, #theme.gradient)
+    local entry = theme.gradient[gradient_idx]
+
+    if not entry then
+        return nil
+    end
+
+    local bg = entry.bg or '#808080'
+    local fg = entry.fg or '#d0d0d0'
+
+    if bar_type == 'winbar' then
+        bg = M.adjust_color(bg, -10)
+    end
+
+    return {
+        fg = fg,
+        bg = bg,
+    }
+end
+```
+
+**Step 2: Update semantic strategy create_highlight**
+
+```lua
+create_highlight = function(group_name, bar_type)
+    local themes = require('luxline.themes')
+    local theme = themes.get_current_theme()
+
+    if not theme or not theme.semantic or not theme.semantic[group_name] then
+        return nil
+    end
+
+    local semantic_def = theme.semantic[group_name]
+    local fg = semantic_def.fg or (theme.gradient[1] and theme.gradient[1].fg) or '#d0d0d0'
+    local bg = semantic_def.bg or (theme.gradient[4] and theme.gradient[4].bg) or '#808080'
+
+    if bar_type == 'winbar' then
+        bg = M.adjust_color(bg, -10)
+    end
+
+    return {
+        fg = fg,
+        bg = bg,
+        bold = semantic_def.bold,
+        italic = semantic_def.italic,
+        underline = semantic_def.underline,
+    }
+end
+```
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/rendering/highlight_strategies.lua
+git commit -m "feat(rendering): update strategies for per-position fg/bg"
+```
+
+---
+
+### Task 8: Integrate Auto-Generation into themes/init.lua
+
+**Files:**
+- Modify: `lua/luxline/themes/init.lua`
+
+**Step 1: Update set_theme to try auto-generation**
+
+```lua
+function M.set_theme(theme_name)
+    theme_name = theme_name or vim.g.colors_name or 'default'
+
+    local theme = M.get_theme(theme_name)
+
+    if not theme then
+        local auto = require('luxline.themes.auto')
+        theme = auto.generate(vim.g.colors_name)
+
+        if theme then
+            theme = M.validate_theme(theme, 'auto:' .. (vim.g.colors_name or 'unknown'))
+        end
+    end
+
+    if not theme then
+        if theme_name ~= 'default' then
+            vim.notify('Theme not found: ' .. theme_name .. ', falling back to default', vim.log.levels.WARN)
+            theme = M.get_theme('default')
+        end
+
+        if not theme then
+            vim.notify('Default theme not available!', vim.log.levels.ERROR)
+            return false
+        end
+    end
+
+    current_theme = theme
+    state.set('theme', theme_name)
+
+    local highlight = require('luxline.rendering.highlight')
+    highlight.clear_highlights()
+
+    events.emit('theme_changed', {
+        name = theme_name,
+        theme = theme
+    })
+
+    return true
+end
+```
+
+**Step 2: Update colorscheme_changed handler in setup**
+
+```lua
+events.on('colorscheme_changed', function()
+    local auto = require('luxline.themes.auto')
+    auto.invalidate(vim.g.colors_name)
+    M.set_theme(vim.g.colors_name)
+end)
+```
+
+**Step 3: Commit**
+
+```bash
+git add lua/luxline/themes/init.lua
+git commit -m "feat(themes): integrate auto-generation fallback"
+```
+
+---
+
+### Task 9: Update default.lua
+
+**Files:**
+- Modify: `lua/luxline/themes/default.lua`
+
+**Step 1: Update to use auto-generation or lux-vesper**
+
+```lua
+local themes = require('luxline.themes')
+
+themes.register('default', function()
+    local lux_vesper = themes.get_theme('lux-vesper')
+    if lux_vesper then
+        return lux_vesper
+    end
+
+    local auto = require('luxline.themes.auto')
+    return auto.generate()
+end)
+```
+
+**Step 2: Commit**
+
+```bash
+git add lua/luxline/themes/default.lua
+git commit -m "feat(themes): update default to use auto-generation fallback"
+```
+
+---
+
+### Task 10: Manual Testing
+
+**Step 1: Reload luxline**
+
+```lua
+:lua require('luxline').reload()
+```
+
+**Step 2: Test with current colorscheme**
+
+```lua
+:lua print(vim.inspect(require('luxline.themes').get_current_theme()))
+```
+Expected: Theme with gradient array of {bg, fg} objects
+
+**Step 3: Test colorscheme switch**
+
+```vim
+:colorscheme default
+:lua print(vim.inspect(require('luxline.themes').get_current_theme()))
+```
+Expected: Auto-generated theme for 'default' colorscheme
+
+**Step 4: Test cache invalidation**
+
+```lua
+:lua require('luxline.themes.auto').invalidate_all()
+:colorscheme <your-theme>
+```
+Expected: Theme regenerates
+
+**Step 5: Verify statusline renders correctly**
+
+Visual inspection - statusline and winbar should render with proper colors
+
+**Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "feat(themes): complete auto-theming implementation"
+```

--- a/lua/luxline/core/update_manager.lua
+++ b/lua/luxline/core/update_manager.lua
@@ -3,18 +3,25 @@ local M = {}
 local config = require('luxline.config')
 local bar_builder = require('luxline.rendering.bar_builder')
 local state = require('luxline.core.state')
+local events = require('luxline.core.events')
 
 local update_timer = nil
 
 function M.setup_events()
     local group = vim.api.nvim_create_augroup('LuxlineUpdate', { clear = true })
-    
+
     vim.api.nvim_create_autocmd({'BufEnter', 'WinEnter', 'BufWritePost'}, {
         group = group,
         callback = function()
             M.throttled_update()
         end,
     })
+
+    events.on('theme_changed', function()
+        vim.schedule(function()
+            M.update()
+        end)
+    end)
 end
 
 function M.update()

--- a/lua/luxline/rendering/highlight_strategies.lua
+++ b/lua/luxline/rendering/highlight_strategies.lua
@@ -22,20 +22,19 @@ highlight_strategies.semantic = {
     create_highlight = function(group_name, bar_type)
         local themes = require('luxline.themes')
         local theme = themes.get_current_theme()
-        
+
         if not theme or not theme.semantic or not theme.semantic[group_name] then
             return nil
         end
-        
+
         local semantic_def = theme.semantic[group_name]
-        local fg = semantic_def.fg or theme.foreground or '#d0d0d0'
-        local bg = semantic_def.bg or theme.fallback or '#808080'
-        
-        -- For winbar, use a slightly darker/lighter bg for distinction
+        local fg = semantic_def.fg or (theme.gradient[1] and theme.gradient[1].fg) or '#d0d0d0'
+        local bg = semantic_def.bg or (theme.gradient[4] and theme.gradient[4].bg) or '#808080'
+
         if bar_type == 'winbar' then
             bg = M.adjust_color(bg, -10)
         end
-        
+
         return {
             fg = fg,
             bg = bg,
@@ -61,20 +60,25 @@ highlight_strategies.positional = {
     create_highlight = function(group_name, side, idx, bar_type)
         local themes = require('luxline.themes')
         local theme = themes.get_current_theme()
-        
-        if not theme then
+
+        if not theme or not theme.gradient then
             return nil
         end
-        
-        local bg_key = 'item' .. side:gsub('^%l', string.upper) .. idx
-        local bg = theme[bg_key] or theme.fallback or '#808080'
-        local fg = theme.foreground or '#d0d0d0'
-        
-        -- For winbar, use a slightly darker/lighter bg for distinction
+
+        local gradient_idx = math.min(idx, #theme.gradient)
+        local entry = theme.gradient[gradient_idx]
+
+        if not entry then
+            return nil
+        end
+
+        local bg = entry.bg or '#808080'
+        local fg = entry.fg or '#d0d0d0'
+
         if bar_type == 'winbar' then
             bg = M.adjust_color(bg, -10)
         end
-        
+
         return {
             fg = fg,
             bg = bg,

--- a/lua/luxline/themes/auto.lua
+++ b/lua/luxline/themes/auto.lua
@@ -104,6 +104,36 @@ local function build_semantic(gradient)
     return semantic
 end
 
+function M.generate(colorscheme_name)
+    colorscheme_name = colorscheme_name or vim.g.colors_name or 'default'
+
+    if theme_cache[colorscheme_name] then
+        return theme_cache[colorscheme_name]
+    end
+
+    local gradient = build_gradient()
+    local semantic = build_semantic(gradient)
+
+    local theme = {
+        gradient = gradient,
+        middle = gradient[2].bg,
+        semantic = semantic,
+    }
+
+    theme_cache[colorscheme_name] = theme
+    return theme
+end
+
+function M.invalidate(colorscheme_name)
+    if colorscheme_name then
+        theme_cache[colorscheme_name] = nil
+    end
+end
+
+function M.invalidate_all()
+    theme_cache = {}
+end
+
 M._build_gradient = build_gradient
 M._build_semantic = build_semantic
 

--- a/lua/luxline/themes/auto.lua
+++ b/lua/luxline/themes/auto.lua
@@ -1,0 +1,32 @@
+local M = {}
+
+local theme_cache = {}
+
+local function get_hl_colors(group)
+    local ok, hl = pcall(vim.api.nvim_get_hl, 0, { name = group, link = false })
+    if not ok or not hl then
+        return { bg = nil, fg = nil }
+    end
+    return {
+        bg = hl.bg and string.format('#%06x', hl.bg) or nil,
+        fg = hl.fg and string.format('#%06x', hl.fg) or nil,
+    }
+end
+
+local function get_color_with_fallbacks(primary, fallbacks, attr, default)
+    local colors = get_hl_colors(primary)
+    if colors[attr] then
+        return colors
+    end
+
+    for _, fallback in ipairs(fallbacks or {}) do
+        colors = get_hl_colors(fallback)
+        if colors[attr] then
+            return colors
+        end
+    end
+
+    return { bg = default, fg = default }
+end
+
+return M

--- a/lua/luxline/themes/auto.lua
+++ b/lua/luxline/themes/auto.lua
@@ -62,6 +62,49 @@ local function build_gradient()
     return gradient
 end
 
+local SEMANTIC_MAPPING = {
+    LuxlineFilename = { primary = 'Title', fallback_pos = 5 },
+    LuxlineWinbarFilename = { primary = 'Title', fallback_pos = 4 },
+    LuxlineModified = { primary = 'DiagnosticWarn', fallbacks = { 'WarningMsg' }, bold = true },
+    LuxlineWinbarModified = { primary = 'DiagnosticWarn', fallbacks = { 'WarningMsg' }, bold = true },
+    LuxlineGit = { primary = 'GitSignsAdd', fallbacks = { 'DiffAdd', 'String' } },
+    LuxlineWinbarGit = { primary = 'GitSignsAdd', fallbacks = { 'DiffAdd', 'String' } },
+    LuxlinePosition = { primary = 'StatusLine', fallback_pos = 5 },
+    LuxlineWinbarPosition = { primary = 'WinBar', fallback_pos = 4 },
+    LuxlinePercent = { primary = 'Search', fallback_pos = 6 },
+    LuxlineWinbarPercent = { primary = 'IncSearch', fallback_pos = 5 },
+    LuxlineWindownumber = { primary = 'Title', fallback_pos = 3, bold = true },
+    LuxlineWinbarWindownumber = { primary = 'WinBar', fallback_pos = 2, bold = true },
+    LuxlineSpacer = { primary = 'StatusLine', fallback_pos = 2 },
+    LuxlineWinbarSpacer = { primary = 'WinBar', fallback_pos = 2 },
+}
+
+local function build_semantic(gradient)
+    local semantic = {}
+
+    for group_name, mapping in pairs(SEMANTIC_MAPPING) do
+        local colors = get_color_with_fallbacks(mapping.primary, mapping.fallbacks, 'bg', nil)
+        local bg = colors.bg
+        local fg = colors.fg
+
+        if not bg and mapping.fallback_pos and gradient[mapping.fallback_pos] then
+            bg = gradient[mapping.fallback_pos].bg
+            fg = fg or gradient[mapping.fallback_pos].fg
+        end
+
+        if bg then
+            semantic[group_name] = {
+                bg = bg,
+                fg = fg or gradient[1].fg or '#d0d0d0',
+                bold = mapping.bold,
+            }
+        end
+    end
+
+    return semantic
+end
+
 M._build_gradient = build_gradient
+M._build_semantic = build_semantic
 
 return M

--- a/lua/luxline/themes/auto.lua
+++ b/lua/luxline/themes/auto.lua
@@ -29,4 +29,39 @@ local function get_color_with_fallbacks(primary, fallbacks, attr, default)
     return { bg = default, fg = default }
 end
 
+local GRADIENT_MAPPING = {
+    { primary = 'Normal', fallbacks = { 'StatusLine' }, attr = 'bg', default = '#1a1a1a' },
+    { primary = 'CursorLine', fallbacks = { 'StatusLineNC' }, attr = 'bg', default = nil },
+    { primary = 'Visual', fallbacks = { 'Pmenu' }, attr = 'bg', default = nil },
+    { primary = 'StatusLine', fallbacks = { 'Normal' }, attr = 'bg', default = nil },
+    { primary = 'Search', fallbacks = { 'WildMenu' }, attr = 'bg', default = nil },
+    { primary = 'IncSearch', fallbacks = { 'Substitute' }, attr = 'bg', default = nil },
+    { primary = 'Cursor', fallbacks = { 'Title', 'MatchParen' }, attr = 'bg', default = nil },
+}
+
+local function build_gradient()
+    local gradient = {}
+    local normal_fg = get_hl_colors('Normal').fg or '#d0d0d0'
+
+    for i, mapping in ipairs(GRADIENT_MAPPING) do
+        local colors = get_color_with_fallbacks(mapping.primary, mapping.fallbacks, mapping.attr, mapping.default)
+        local bg = colors.bg
+        local fg = colors.fg or normal_fg
+
+        if not bg and i > 1 then
+            bg = gradient[i - 1].bg
+        end
+
+        if not bg then
+            bg = mapping.default or '#1a1a1a'
+        end
+
+        gradient[i] = { bg = bg, fg = fg }
+    end
+
+    return gradient
+end
+
+M._build_gradient = build_gradient
+
 return M

--- a/lua/luxline/themes/data/lux-themes.lua
+++ b/lua/luxline/themes/data/lux-themes.lua
@@ -1,13 +1,41 @@
--- LUX theme definitions
--- Extracted from themes/init.lua for better maintainability
-
 return {
-    ['lux-vesper'] = {
-        foreground = '#e0e7ff',
-        fallback = '#4a3674',
+    ['nami'] = {
         gradient = {
-            '#0f0f23', '#1a1a2e', '#2A305E', '#4a3674',
-            '#7c3aed', '#8b5cf6', '#a855f7'
+            { bg = '#0d1821', fg = '#e8dcc8' },
+            { bg = '#1a2734', fg = '#e8dcc8' },
+            { bg = '#2a3a4a', fg = '#e8dcc8' },
+            { bg = '#3a9ba8', fg = '#e8dcc8' },
+            { bg = '#4fc9c9', fg = '#0d1821' },
+            { bg = '#ff8c6b', fg = '#0d1821' },
+            { bg = '#ffd48c', fg = '#0d1821' },
+        },
+        middle = '#1a2734',
+        semantic = {
+            LuxlineFilename = { fg = '#e8dcc8', bg = '#4fc9c9' },
+            LuxlineWinbarFilename = { fg = '#e8dcc8', bg = '#3a9ba8' },
+            LuxlineModified = { fg = '#ffd48c', bg = '#ff6b4a', bold = true },
+            LuxlineWinbarModified = { fg = '#ffd48c', bg = '#ff6b4a', bold = true },
+            LuxlineGit = { fg = '#4fc9c9', bg = '#2a3a4a' },
+            LuxlineWinbarGit = { fg = '#4fc9c9', bg = '#1a2734' },
+            LuxlinePosition = { fg = '#e8dcc8', bg = '#ff8c6b' },
+            LuxlineWinbarPosition = { fg = '#e8dcc8', bg = '#3a9ba8' },
+            LuxlinePercent = { fg = '#0d1821', bg = '#ffd48c' },
+            LuxlineWinbarPercent = { fg = '#0d1821', bg = '#ffa857' },
+            LuxlineWindownumber = { fg = '#ffd48c', bg = '#2a3a4a', bold = true },
+            LuxlineWinbarWindownumber = { fg = '#ffd48c', bg = '#1a2734', bold = true },
+            LuxlineSpacer = { fg = '#1a2734', bg = '#1a2734' },
+            LuxlineWinbarSpacer = { fg = '#1a2734', bg = '#1a2734' },
+        },
+    },
+    ['lux-vesper'] = {
+        gradient = {
+            { bg = '#0f0f23', fg = '#e0e7ff' },
+            { bg = '#1a1a2e', fg = '#e0e7ff' },
+            { bg = '#2A305E', fg = '#e0e7ff' },
+            { bg = '#4a3674', fg = '#e0e7ff' },
+            { bg = '#7c3aed', fg = '#ffffff' },
+            { bg = '#8b5cf6', fg = '#ffffff' },
+            { bg = '#a855f7', fg = '#1a1a1a' },
         },
         middle = '#1a1a2e',
         semantic = {
@@ -24,43 +52,119 @@ return {
             LuxlineWindownumber = { fg = '#fbbf24', bg = '#4a3674', bold = true },
             LuxlineWinbarWindownumber = { fg = '#fbbf24', bg = '#3c2e60', bold = true },
             LuxlineSpacer = { fg = '#1a1a2e', bg = '#1a1a2e' },
-            LuxlineWinbarSpacer = { fg = '#1a1a2e', bg = '#1a1a2e' }
-        }
+            LuxlineWinbarSpacer = { fg = '#1a1a2e', bg = '#1a1a2e' },
+        },
     },
     ['lux-aurora'] = {
-        foreground = '#1a1a1a',
-        fallback = '#00bfa5',
         gradient = {
-            '#f2f8f9', '#ecf4f6', '#e0ecef', '#b3e5fc',
-            '#00bfa5', '#00e5ff', '#7c4dff'
+            { bg = '#f2f8f9', fg = '#1a1a1a' },
+            { bg = '#ecf4f6', fg = '#1a1a1a' },
+            { bg = '#e0ecef', fg = '#1a1a1a' },
+            { bg = '#b3e5fc', fg = '#1a1a1a' },
+            { bg = '#00bfa5', fg = '#ffffff' },
+            { bg = '#00e5ff', fg = '#1a1a1a' },
+            { bg = '#7c4dff', fg = '#ffffff' },
         },
-        middle = '#ecf4f6'
+        middle = '#ecf4f6',
+        semantic = {
+            LuxlineFilename = { fg = '#ffffff', bg = '#00bfa5' },
+            LuxlineWinbarFilename = { fg = '#1a1a1a', bg = '#b3e5fc' },
+            LuxlineModified = { fg = '#ffffff', bg = '#f44336', bold = true },
+            LuxlineWinbarModified = { fg = '#ffffff', bg = '#e53935', bold = true },
+            LuxlineGit = { fg = '#1a1a1a', bg = '#e0ecef' },
+            LuxlineWinbarGit = { fg = '#1a1a1a', bg = '#ecf4f6' },
+            LuxlinePosition = { fg = '#1a1a1a', bg = '#00e5ff' },
+            LuxlineWinbarPosition = { fg = '#1a1a1a', bg = '#b3e5fc' },
+            LuxlinePercent = { fg = '#ffffff', bg = '#7c4dff' },
+            LuxlineWinbarPercent = { fg = '#ffffff', bg = '#00bfa5' },
+            LuxlineWindownumber = { fg = '#1a1a1a', bg = '#e0ecef', bold = true },
+            LuxlineWinbarWindownumber = { fg = '#1a1a1a', bg = '#ecf4f6', bold = true },
+            LuxlineSpacer = { fg = '#ecf4f6', bg = '#ecf4f6' },
+            LuxlineWinbarSpacer = { fg = '#ecf4f6', bg = '#ecf4f6' },
+        },
     },
     ['lux-chroma'] = {
-        foreground = '#1a1a1a',
-        fallback = '#20b2aa',
         gradient = {
-            '#fdfbf3', '#faf7ed', '#f4f0e1', '#fffdd0',
-            '#20b2aa', '#ff8c42', '#ff69b4'
+            { bg = '#fdfbf3', fg = '#1a1a1a' },
+            { bg = '#faf7ed', fg = '#1a1a1a' },
+            { bg = '#f4f0e1', fg = '#1a1a1a' },
+            { bg = '#fffdd0', fg = '#1a1a1a' },
+            { bg = '#20b2aa', fg = '#ffffff' },
+            { bg = '#ff8c42', fg = '#1a1a1a' },
+            { bg = '#ff69b4', fg = '#ffffff' },
         },
-        middle = '#faf7ed'
+        middle = '#faf7ed',
+        semantic = {
+            LuxlineFilename = { fg = '#ffffff', bg = '#20b2aa' },
+            LuxlineWinbarFilename = { fg = '#1a1a1a', bg = '#fffdd0' },
+            LuxlineModified = { fg = '#ffffff', bg = '#e53935', bold = true },
+            LuxlineWinbarModified = { fg = '#ffffff', bg = '#d32f2f', bold = true },
+            LuxlineGit = { fg = '#1a1a1a', bg = '#f4f0e1' },
+            LuxlineWinbarGit = { fg = '#1a1a1a', bg = '#faf7ed' },
+            LuxlinePosition = { fg = '#1a1a1a', bg = '#ff8c42' },
+            LuxlineWinbarPosition = { fg = '#1a1a1a', bg = '#fffdd0' },
+            LuxlinePercent = { fg = '#ffffff', bg = '#ff69b4' },
+            LuxlineWinbarPercent = { fg = '#ffffff', bg = '#20b2aa' },
+            LuxlineWindownumber = { fg = '#1a1a1a', bg = '#f4f0e1', bold = true },
+            LuxlineWinbarWindownumber = { fg = '#1a1a1a', bg = '#faf7ed', bold = true },
+            LuxlineSpacer = { fg = '#faf7ed', bg = '#faf7ed' },
+            LuxlineWinbarSpacer = { fg = '#faf7ed', bg = '#faf7ed' },
+        },
     },
     ['lux-eos'] = {
-        foreground = '#1a1a1a',
-        fallback = '#ff8e53',
         gradient = {
-            '#fef4f1', '#fdefeb', '#fbe4df', '#ffab91',
-            '#ff8e53', '#26d0ce', '#ff6b6b'
+            { bg = '#fef4f1', fg = '#1a1a1a' },
+            { bg = '#fdefeb', fg = '#1a1a1a' },
+            { bg = '#fbe4df', fg = '#1a1a1a' },
+            { bg = '#ffab91', fg = '#1a1a1a' },
+            { bg = '#ff8e53', fg = '#ffffff' },
+            { bg = '#26d0ce', fg = '#1a1a1a' },
+            { bg = '#ff6b6b', fg = '#ffffff' },
         },
-        middle = '#fdefeb'
+        middle = '#fdefeb',
+        semantic = {
+            LuxlineFilename = { fg = '#ffffff', bg = '#ff8e53' },
+            LuxlineWinbarFilename = { fg = '#1a1a1a', bg = '#ffab91' },
+            LuxlineModified = { fg = '#ffffff', bg = '#d32f2f', bold = true },
+            LuxlineWinbarModified = { fg = '#ffffff', bg = '#c62828', bold = true },
+            LuxlineGit = { fg = '#1a1a1a', bg = '#fbe4df' },
+            LuxlineWinbarGit = { fg = '#1a1a1a', bg = '#fdefeb' },
+            LuxlinePosition = { fg = '#1a1a1a', bg = '#26d0ce' },
+            LuxlineWinbarPosition = { fg = '#1a1a1a', bg = '#ffab91' },
+            LuxlinePercent = { fg = '#ffffff', bg = '#ff6b6b' },
+            LuxlineWinbarPercent = { fg = '#ffffff', bg = '#ff8e53' },
+            LuxlineWindownumber = { fg = '#1a1a1a', bg = '#fbe4df', bold = true },
+            LuxlineWinbarWindownumber = { fg = '#1a1a1a', bg = '#fdefeb', bold = true },
+            LuxlineSpacer = { fg = '#fdefeb', bg = '#fdefeb' },
+            LuxlineWinbarSpacer = { fg = '#fdefeb', bg = '#fdefeb' },
+        },
     },
     ['lux-umbra'] = {
-        foreground = '#f4edff',
-        fallback = '#5b3094',
         gradient = {
-            '#0a0310', '#180c24', '#2c1a42', '#5b3094',
-            '#6b60e3', '#c471ed', '#d776dd'
+            { bg = '#0a0310', fg = '#f4edff' },
+            { bg = '#180c24', fg = '#f4edff' },
+            { bg = '#2c1a42', fg = '#f4edff' },
+            { bg = '#5b3094', fg = '#f4edff' },
+            { bg = '#6b60e3', fg = '#ffffff' },
+            { bg = '#c471ed', fg = '#1a1a1a' },
+            { bg = '#d776dd', fg = '#1a1a1a' },
         },
-        middle = '#180c24'
-    }
+        middle = '#180c24',
+        semantic = {
+            LuxlineFilename = { fg = '#ffffff', bg = '#6b60e3' },
+            LuxlineWinbarFilename = { fg = '#f4edff', bg = '#5b3094' },
+            LuxlineModified = { fg = '#fbbf24', bg = '#dc2626', bold = true },
+            LuxlineWinbarModified = { fg = '#fbbf24', bg = '#b91c1c', bold = true },
+            LuxlineGit = { fg = '#a7f3d0', bg = '#2c1a42' },
+            LuxlineWinbarGit = { fg = '#a7f3d0', bg = '#180c24' },
+            LuxlinePosition = { fg = '#1a1a1a', bg = '#c471ed' },
+            LuxlineWinbarPosition = { fg = '#f4edff', bg = '#5b3094' },
+            LuxlinePercent = { fg = '#1a1a1a', bg = '#d776dd' },
+            LuxlineWinbarPercent = { fg = '#ffffff', bg = '#6b60e3' },
+            LuxlineWindownumber = { fg = '#d776dd', bg = '#2c1a42', bold = true },
+            LuxlineWinbarWindownumber = { fg = '#c471ed', bg = '#180c24', bold = true },
+            LuxlineSpacer = { fg = '#180c24', bg = '#180c24' },
+            LuxlineWinbarSpacer = { fg = '#180c24', bg = '#180c24' },
+        },
+    },
 }

--- a/lua/luxline/themes/default.lua
+++ b/lua/luxline/themes/default.lua
@@ -1,5 +1,11 @@
 local themes = require('luxline.themes')
 
 themes.register('default', function()
-    return themes.get_theme('lux-vesper')
+    local lux_vesper = themes.get_theme('lux-vesper')
+    if lux_vesper then
+        return lux_vesper
+    end
+
+    local auto = require('luxline.themes.auto')
+    return auto.generate()
 end)

--- a/lua/luxline/themes/init.lua
+++ b/lua/luxline/themes/init.lua
@@ -48,31 +48,41 @@ end
 
 function M.set_theme(theme_name)
     theme_name = theme_name or vim.g.colors_name or 'default'
-    
+
     local theme = M.get_theme(theme_name)
+
+    if not theme then
+        local auto = require('luxline.themes.auto')
+        theme = auto.generate(vim.g.colors_name)
+
+        if theme then
+            theme = M.validate_theme(theme, 'auto:' .. (vim.g.colors_name or 'unknown'))
+        end
+    end
+
     if not theme then
         if theme_name ~= 'default' then
             vim.notify('Theme not found: ' .. theme_name .. ', falling back to default', vim.log.levels.WARN)
             theme = M.get_theme('default')
         end
-        
+
         if not theme then
             vim.notify('Default theme not available!', vim.log.levels.ERROR)
             return false
         end
     end
-    
+
     current_theme = theme
     state.set('theme', theme_name)
-    
+
     local highlight = require('luxline.rendering.highlight')
     highlight.clear_highlights()
-    
-    events.emit('theme_changed', { 
-        name = theme_name, 
-        theme = theme 
+
+    events.emit('theme_changed', {
+        name = theme_name,
+        theme = theme
     })
-    
+
     return true
 end
 
@@ -129,13 +139,18 @@ end
 
 function M.create_gradient_theme(name, start_color, end_color, foreground)
     local colors = M.interpolate_colors(start_color, end_color, 7)
-    
+    foreground = foreground or '#ffffff'
+
+    local gradient = {}
+    for i, bg in ipairs(colors) do
+        gradient[i] = { bg = bg, fg = foreground }
+    end
+
     local theme = {
-        foreground = foreground or '#ffffff',
-        fallback = colors[4],
-        gradient = colors
+        gradient = gradient,
+        middle = colors[2],
     }
-    
+
     M.register(name, theme)
     return name
 end
@@ -193,18 +208,9 @@ function M.setup()
     end
     
     events.on('colorscheme_changed', function()
-        -- Auto-detect lux themes when colorscheme changes
-        if vim.g.colors_name and vim.g.colors_name:match("^lux%-") then
-            M.set_theme(vim.g.colors_name)
-        else
-            local current_theme_name = state.get('theme')
-            if current_theme_name then
-                M.set_theme(current_theme_name)
-            else
-                -- Fallback: refresh theme based on new colorscheme
-                M.set_theme()
-            end
-        end
+        local auto = require('luxline.themes.auto')
+        auto.invalidate(vim.g.colors_name)
+        M.set_theme(vim.g.colors_name)
     end)
 end
 

--- a/lua/luxline/themes/validation.lua
+++ b/lua/luxline/themes/validation.lua
@@ -2,22 +2,22 @@ local M = {}
 
 local utils = require('luxline.core.utils')
 
--- Default theme structure
 M.DEFAULT_THEME = {
-    foreground = '#d0d0d0',
-    fallback = '#808080',
-    gradient = {}
+    gradient = {},
+    middle = '#1a1a2e',
 }
 
 function M.get_default_theme()
     local default = vim.deepcopy(M.DEFAULT_THEME)
-    
-    -- Generate default gradient if not provided
+    local normal_fg = '#d0d0d0'
+
     for i = 1, 7 do
         local gray_value = math.floor(0x40 + (i - 1) * 0x10)
-        default.gradient[i] = string.format('#%02x%02x%02x', gray_value, gray_value, gray_value)
+        local bg = string.format('#%02x%02x%02x', gray_value, gray_value, gray_value)
+        default.gradient[i] = { bg = bg, fg = normal_fg }
     end
-    
+
+    default.middle = default.gradient[2].bg
     return default
 end
 
@@ -26,36 +26,23 @@ function M.validate_theme(theme, name)
         vim.notify('Theme must be a table: ' .. (name or 'unknown'), vim.log.levels.WARN)
         return M.get_default_theme()
     end
-    
-    -- Start with defaults and merge user theme
+
     local validated = utils.deep_merge(M.get_default_theme(), theme)
-    
-    -- Ensure gradient has exactly 7 colors
+
     if not validated.gradient or #validated.gradient ~= 7 then
         if name then
             vim.notify('Theme gradient must have exactly 7 colors: ' .. name, vim.log.levels.WARN)
         end
-        
-        -- Fill missing colors or create new gradient
-        validated.gradient = validated.gradient or {}
-        for i = #validated.gradient + 1, 7 do
-            validated.gradient[i] = validated.fallback
-        end
-        
-        -- Trim if too many colors
-        if #validated.gradient > 7 then
-            for i = 8, #validated.gradient do
-                validated.gradient[i] = nil
-            end
+        validated = M.get_default_theme()
+    end
+
+    for i, entry in ipairs(validated.gradient) do
+        if type(entry) ~= 'table' or not entry.bg then
+            vim.notify('Invalid gradient entry at position ' .. i, vim.log.levels.WARN)
+            validated.gradient[i] = { bg = '#808080', fg = '#d0d0d0' }
         end
     end
-    
-    -- Generate legacy itemLeft/Right from gradient for compatibility
-    for i = 1, 7 do
-        validated['itemLeft' .. i] = validated.gradient[i]
-        validated['itemRight' .. i] = validated.gradient[i]
-    end
-    
+
     return validated
 end
 
@@ -63,8 +50,7 @@ function M.validate_color(color)
     if type(color) ~= 'string' then
         return false
     end
-    
-    -- Check if it's a valid hex color
+
     return color:match('^#%x%x%x%x%x%x$') ~= nil
 end
 
@@ -72,17 +58,23 @@ function M.validate_gradient(gradient)
     if type(gradient) ~= 'table' then
         return false, 'Gradient must be a table'
     end
-    
+
     if #gradient ~= 7 then
-        return false, 'Gradient must have exactly 7 colors'
+        return false, 'Gradient must have exactly 7 entries'
     end
-    
-    for i, color in ipairs(gradient) do
-        if not M.validate_color(color) then
-            return false, 'Invalid color at position ' .. i .. ': ' .. tostring(color)
+
+    for i, entry in ipairs(gradient) do
+        if type(entry) ~= 'table' then
+            return false, 'Gradient entry ' .. i .. ' must be a table'
+        end
+        if not M.validate_color(entry.bg) then
+            return false, 'Invalid bg color at position ' .. i
+        end
+        if entry.fg and not M.validate_color(entry.fg) then
+            return false, 'Invalid fg color at position ' .. i
         end
     end
-    
+
     return true
 end
 
@@ -90,21 +82,21 @@ function M.validate_semantic_groups(semantic)
     if type(semantic) ~= 'table' then
         return false, 'Semantic groups must be a table'
     end
-    
+
     for group_name, group_def in pairs(semantic) do
         if type(group_def) ~= 'table' then
             return false, 'Semantic group definition must be a table: ' .. group_name
         end
-        
+
         if group_def.fg and not M.validate_color(group_def.fg) then
             return false, 'Invalid foreground color in group: ' .. group_name
         end
-        
+
         if group_def.bg and not M.validate_color(group_def.bg) then
             return false, 'Invalid background color in group: ' .. group_name
         end
     end
-    
+
     return true
 end
 


### PR DESCRIPTION
## Summary
- Add `themes/auto.lua` module that extracts colors from vim highlight groups to auto-generate luxline themes
- Migrate all lux-themes to new `{bg, fg}` gradient format with per-position foreground colors
- Integrate auto-generation fallback when theme not found in registry
- Subscribe update_manager to `theme_changed` events for immediate statusline refresh

## Test Plan
- [x] Reload luxline and verify current theme displays correctly
- [x] Switch colorscheme with `:colorscheme <name>` and verify immediate update
- [x] Test cache invalidation with `require('luxline.themes.auto').invalidate_all()`
- [x] Visual verification of statusline/winbar rendering