### PR TITLE
test: headless test harness and render baseline (phase 0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ luac.out
 CLAUDE.md
 docs/plans/
 docs/superpowers/
+tests/baseline/

--- a/scripts/render_baseline.lua
+++ b/scripts/render_baseline.lua
@@ -1,0 +1,32 @@
+local root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h')
+vim.opt.runtimepath:prepend(root)
+
+local mode = (_G.arg and _G.arg[1]) or 'capture'
+
+require('luxline').setup({ git_enabled = false })
+vim.cmd('edit ' .. root .. '/README.md')
+require('luxline').update()
+
+local bar_builder = require('luxline.rendering.bar_builder')
+local lines = {
+    'statusline:' .. bar_builder.statusline.preview(),
+    'winbar:' .. bar_builder.winbar.preview(),
+}
+
+local baseline_path = root .. '/tests/baseline/rendered.txt'
+if mode == 'capture' then
+    vim.fn.mkdir(root .. '/tests/baseline', 'p')
+    vim.fn.writefile(lines, baseline_path)
+    print('baseline captured to ' .. baseline_path)
+else
+    local expected = vim.fn.readfile(baseline_path)
+    if not vim.deep_equal(expected, lines) then
+        print('BASELINE MISMATCH')
+        print('expected:')
+        print(table.concat(expected, '\n'))
+        print('actual:')
+        print(table.concat(lines, '\n'))
+        os.exit(1)
+    end
+    print('baseline match')
+end

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/.."
+nvim --headless --noplugin -u tests/minimal_init.lua -l tests/run.lua

--- a/tests/helpers/assert.lua
+++ b/tests/helpers/assert.lua
@@ -1,0 +1,43 @@
+local M = {}
+
+local function format_value(value)
+    if type(value) == 'table' then
+        return vim.inspect(value)
+    end
+    return tostring(value)
+end
+
+function M.eq(actual, expected, message)
+    if not vim.deep_equal(actual, expected) then
+        error(string.format('%s\nexpected: %s\nactual:   %s',
+            message or 'values differ', format_value(expected), format_value(actual)), 2)
+    end
+end
+
+function M.truthy(value, message)
+    if not value then
+        error(message or ('expected truthy, got ' .. tostring(value)), 2)
+    end
+end
+
+function M.falsy(value, message)
+    if value then
+        error(message or ('expected falsy, got ' .. format_value(value)), 2)
+    end
+end
+
+function M.matches(pattern, text, message)
+    if type(text) ~= 'string' or not text:match(pattern) then
+        error(string.format('%s\npattern: %s\ntext:    %s',
+            message or 'pattern not matched', pattern, format_value(text)), 2)
+    end
+end
+
+function M.errors(fn, message)
+    local ok = pcall(fn)
+    if ok then
+        error(message or 'expected function to error', 2)
+    end
+end
+
+return M

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -1,0 +1,2 @@
+local root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h')
+vim.opt.runtimepath:prepend(root)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,0 +1,51 @@
+local root = vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h')
+local spec_files = vim.fn.glob(root .. '/tests/spec/*_spec.lua', false, true)
+table.sort(spec_files)
+
+local results = { passed = 0, failed = 0, failures = {} }
+
+local function clear_luxline_modules()
+    for name in pairs(package.loaded) do
+        if name == 'luxline' or name:match('^luxline%.') then
+            package.loaded[name] = nil
+        end
+    end
+end
+
+_G.describe = function(name, body)
+    _G.__current_group = name
+    body()
+end
+
+_G.it = function(name, body)
+    local label = (_G.__current_group or '?') .. ' :: ' .. name
+    local ok, err = pcall(body)
+    if ok then
+        results.passed = results.passed + 1
+        print('PASS  ' .. label)
+    else
+        results.failed = results.failed + 1
+        table.insert(results.failures, { label = label, err = err })
+        print('FAIL  ' .. label)
+    end
+end
+
+for _, file in ipairs(spec_files) do
+    _G.__current_group = nil
+    clear_luxline_modules()
+    local ok, err = pcall(dofile, file)
+    if not ok then
+        results.failed = results.failed + 1
+        table.insert(results.failures, { label = file, err = err })
+        print('ERROR ' .. file)
+    end
+end
+
+print(string.format('\n%d passed, %d failed', results.passed, results.failed))
+for _, failure in ipairs(results.failures) do
+    print(string.format('\n--- %s\n%s', failure.label, tostring(failure.err)))
+end
+
+if results.failed > 0 then
+    os.exit(1)
+end

--- a/tests/spec/harness_spec.lua
+++ b/tests/spec/harness_spec.lua
@@ -1,0 +1,16 @@
+local assert = dofile(vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h') .. '/helpers/assert.lua')
+
+describe('harness', function()
+    it('asserts equality on tables and scalars', function()
+        assert.eq(1 + 1, 2)
+        assert.eq({ a = { 1, 2 } }, { a = { 1, 2 } })
+    end)
+
+    it('detects expected errors', function()
+        assert.errors(function() error('boom') end)
+    end)
+
+    it('loads luxline from the repo runtimepath', function()
+        assert.eq(require('luxline')._VERSION, '2.0.0')
+    end)
+end)


### PR DESCRIPTION
Phase 0 of the primitive-first refactor: zero-dependency headless test runner (scripts/run_tests.sh, tests/run.lua, assert helper, harness self-test) and the render-baseline capture script used as a regression gate by later phases.

Gates verified: suite 3/3 passing, baseline capture + compare green.