### PR TITLE
refactor(rendering): separator dedup, generated bar APIs (phase 5)

### DIFF
--- a/lua/luxline/rendering/bar_builder.lua
+++ b/lua/luxline/rendering/bar_builder.lua
@@ -2,38 +2,37 @@ local M = {}
 
 local config = require('luxline.config')
 local items = require('luxline.items')
+local highlight = require('luxline.rendering.highlight')
 local window_context = require('luxline.core.context')
 local tbl = require('luxline.primitives.table')
-local highlight = require('luxline.rendering.highlight')
 local events = require('luxline.core.events')
 
-function M.build_for_context(context, bar_type)
+function M.build_for_context(ctx, bar_type)
     bar_type = bar_type or 'statusline'
-    local status_type = context.active and 'active' or 'inactive'
-    local left_section = M.build_section('left', status_type, context, bar_type)
-    local right_section = M.build_section('right', status_type, context, bar_type)
-    
+    local status_type = ctx.active and 'active' or 'inactive'
+    local left_section = M.build_section('left', status_type, ctx, bar_type)
+    local right_section = M.build_section('right', status_type, ctx, bar_type)
+
     return table.concat(left_section, '') .. '%=' .. table.concat(right_section, '')
 end
 
-function M.build_section(side, status_type, context, bar_type)
+function M.build_section(side, status_type, ctx, bar_type)
     bar_type = bar_type or 'statusline'
-    local item_list = config.get_items(side, status_type, context.filetype, bar_type, context.buftype)
+    local item_list = config.get_items(side, status_type, ctx.filetype, bar_type, ctx.buftype)
     local separator = config.get_separator(side, bar_type)
     local section = {}
-    
+
     if side == 'right' then
         item_list = tbl.reverse(item_list)
     end
-    
-    -- First pass: collect valid items with their rendered positions
+
     local valid_items = {}
     local rendered_position = 1
-    
+
     for idx, item_spec in ipairs(item_list) do
         local item_name, variant = items.parse_spec(item_spec)
-        local item_value = items.get_value(item_name, variant, context)
-        
+        local item_value = items.get_value(item_name, variant, ctx)
+
         if item_value and item_value ~= '' then
             valid_items[#valid_items + 1] = {
                 original_idx = idx,
@@ -45,8 +44,7 @@ function M.build_section(side, status_type, context, bar_type)
             rendered_position = rendered_position + 1
         end
     end
-    
-    -- Second pass: build all highlight groups first
+
     local item_highlights = {}
     for i, item_info in ipairs(valid_items) do
         local hl_formatted = highlight.item(item_info.item_value, side, item_info.rendered_idx, bar_type, item_info.item_name)
@@ -54,72 +52,45 @@ function M.build_section(side, status_type, context, bar_type)
         item_highlights[i] = {
             formatted = hl_formatted,
             group_name = hl_group_name,
-            item_info = item_info
         }
     end
-    
-    -- Third pass: build section with separators
+
     for i, hl_info in ipairs(item_highlights) do
-        local hl_sep = ''
-        
         if side == 'left' then
-            -- Left side: separator after item
             local next_hl_group = (i < #item_highlights) and item_highlights[i + 1].group_name or nil
-            hl_sep = highlight.separator_direct(separator, side, hl_info.group_name, next_hl_group, bar_type)
+            local hl_sep = highlight.separator_direct(separator, side, hl_info.group_name, next_hl_group, bar_type)
             table.insert(section, hl_info.formatted .. hl_sep)
         else
-            -- Right side: separator before item
             local prev_hl_group = (i > 1) and item_highlights[i - 1].group_name or nil
-            hl_sep = highlight.separator_direct(separator, side, prev_hl_group, hl_info.group_name, bar_type)
+            local hl_sep = highlight.separator_direct(separator, side, prev_hl_group, hl_info.group_name, bar_type)
             table.insert(section, hl_sep .. hl_info.formatted)
         end
     end
-    
+
     return section
 end
 
+local function render_window(win, ctx, bar_type)
+    if bar_type == 'winbar' and config.is_winbar_disabled_for_filetype(ctx.filetype) then
+        return
+    end
+
+    local content = M.build_for_context(ctx, bar_type)
+    local ok, err = pcall(vim.api.nvim_set_option_value, bar_type, content, { win = win })
+    if not ok then
+        vim.notify('Failed to set ' .. bar_type .. ' for window ' .. win .. ': ' .. err, vim.log.levels.WARN)
+    end
+end
 
 function M.update_all_windows(bar_type)
     bar_type = bar_type or 'statusline'
     local windows = window_context.gather_window_info()
-    local option_name = bar_type == 'winbar' and 'winbar' or 'statusline'
-    
-    for win, info in pairs(windows) do
-        -- Skip winbar updates for configured disabled filetypes
-        if bar_type == 'winbar' and config.is_winbar_disabled_for_filetype(info.filetype) then
-            goto continue
-        end
-        
-        local content = M.build_for_context(info, bar_type)
-        local ok, err = pcall(vim.api.nvim_set_option_value, option_name, content, { win = win })
-        if not ok then
-            vim.notify('Failed to set ' .. bar_type .. ' for window ' .. win .. ': ' .. err, vim.log.levels.WARN)
-        end
-        
-        ::continue::
-    end
-    
-    events.emit(bar_type .. '_updated', { window_count = vim.tbl_count(windows) })
-end
 
-function M.update_window(winid, bar_type)
-    bar_type = bar_type or 'statusline'
-    local bufnr = vim.api.nvim_win_get_buf(winid)
-    local option_name = bar_type == 'winbar' and 'winbar' or 'statusline'
-    
-    -- Skip winbar updates for configured disabled filetypes
-    if bar_type == 'winbar' then
-        local filetype = vim.api.nvim_buf_get_option(bufnr, 'filetype')
-        if config.is_winbar_disabled_for_filetype(filetype) then
-            return
-        end
+    for win, ctx in pairs(windows) do
+        render_window(win, ctx, bar_type)
     end
-    
-    local context = window_context.create_context(winid, bufnr)
-    local content = M.build_for_context(context, bar_type)
-    vim.api.nvim_set_option_value(option_name, content, { win = winid })
-    
-    events.emit(bar_type .. '_window_updated', { winid = winid })
+
+    events.emit(bar_type .. '_updated', { window_count = vim.tbl_count(windows) })
 end
 
 function M.preview(config_override, bar_type)
@@ -128,53 +99,34 @@ function M.preview(config_override, bar_type)
     if config_override then
         config.setup(tbl.deep_merge(vim.deepcopy(old_config), config_override))
     end
-    
-    local context = window_context.get_current_context()
-    context.active = true
-    
-    local preview = M.build_for_context(context, bar_type)
-    
+
+    local ctx = window_context.get_current_context()
+    ctx.active = true
+
+    local preview = M.build_for_context(ctx, bar_type)
+
     if config_override then
         config.setup(old_config)
     end
-    
+
     return preview
 end
 
--- Statusline API
-M.statusline = {
-    build_for_context = function(context)
-        return M.build_for_context(context, 'statusline')
-    end,
-    build_section = function(side, status_type, context)
-        return M.build_section(side, status_type, context, 'statusline')
-    end,
-    update_all = function()
-        return M.update_all_windows('statusline')
-    end,
-    update_window = function(winid)
-        return M.update_window(winid, 'statusline')
-    end,
-    preview = function(config_override)
-        return M.preview(config_override, 'statusline')
-    end
-}
-
--- Winbar API
-M.winbar = {
-    build_for_context = function(context)
-        return M.build_for_context(context, 'winbar')
-    end,
-    update_all = function()
-        return M.update_all_windows('winbar')
-    end,
-    update_window = function(winid)
-        return M.update_window(winid, 'winbar')
-    end,
-    preview = function(config_override)
-        return M.preview(config_override, 'winbar')
-    end
-}
-
+for _, bar_type in ipairs({ 'statusline', 'winbar' }) do
+    M[bar_type] = {
+        build_for_context = function(ctx)
+            return M.build_for_context(ctx, bar_type)
+        end,
+        build_section = function(side, status_type, ctx)
+            return M.build_section(side, status_type, ctx, bar_type)
+        end,
+        update_all = function()
+            return M.update_all_windows(bar_type)
+        end,
+        preview = function(config_override)
+            return M.preview(config_override, bar_type)
+        end,
+    }
+end
 
 return M

--- a/lua/luxline/rendering/highlight.lua
+++ b/lua/luxline/rendering/highlight.lua
@@ -5,7 +5,6 @@ local strategies = require('luxline.rendering.highlight_strategies')
 
 local active_groups = {}
 local separator_cache = {}
-local item_highlight_mappings = {}
 
 local function format_highlight(name, content)
     if not name or not content or content == '' then
@@ -16,126 +15,67 @@ end
 
 function M.item(value, side, idx, bar_type, item_name)
     bar_type = bar_type or 'statusline'
-    
-    -- Get the appropriate highlight strategy and group name
+
     local strategy_name, group_name = strategies.get_highlight_strategy(item_name, side, idx, bar_type)
-    
+
     if not strategy_name or not group_name then
-        return value -- Return plain value if no highlight available
+        return value
     end
-    
-    -- Ensure the highlight group exists
-    M.ensure_highlight_exists(strategy_name, group_name, side, idx, bar_type, item_name)
-    
-    -- Store the group for separator logic
-    M.store_item_highlight_mapping(side, idx, bar_type, group_name)
-    
+
+    M.ensure_highlight_exists(strategy_name, group_name, side, idx, bar_type)
+
     return format_highlight(group_name, value)
 end
 
-
-function M.ensure_highlight_exists(strategy_name, group_name, side, idx, bar_type, item_name)
+function M.ensure_highlight_exists(strategy_name, group_name, side, idx, bar_type)
     if active_groups[group_name] then
         return group_name
     end
-    
+
     local hl_def
     if strategy_name == 'semantic' then
         hl_def = strategies.create_highlight_group('semantic', group_name, bar_type)
     elseif strategy_name == 'positional' then
         hl_def = strategies.create_highlight_group('positional', group_name, side, idx, bar_type)
     end
-    
+
     if not hl_def then
         vim.notify('No theme available for highlight group: ' .. group_name, vim.log.levels.WARN)
         return group_name
     end
-    
+
     vim.api.nvim_set_hl(0, group_name, hl_def)
     active_groups[group_name] = true
     return group_name
 end
 
-function M.get_highlight_value(hl_name, attr)
-    if not active_groups[hl_name] then
-        return '000000'
-    end
-    
-    local hl = vim.api.nvim_get_hl(0, { name = hl_name })
-    if attr == 'bg' then
-        return hl.bg and string.format('%06x', hl.bg) or '000000'
-    elseif attr == 'fg' then
-        return hl.fg and string.format('%06x', hl.fg) or 'ffffff'
-    end
-    return '000000'
-end
-
-function M.create_highlight(name, fg, bg)
-    vim.api.nvim_set_hl(0, name, {
-        fg = '#' .. fg,
-        bg = '#' .. bg,
-    })
-    active_groups[name] = true
-end
-
-
-function M.store_item_highlight_mapping(side, idx, bar_type, highlight_group)
-    local winid = vim.api.nvim_get_current_win()
-    local key = string.format('%d_%s_%s_%d', winid, bar_type, side, idx)
-    item_highlight_mappings[key] = highlight_group
-end
-
-function M.get_item_highlight_group(side, idx, bar_type)
-    if idx <= 0 then
-        return nil
-    end
-    
-    local winid = vim.api.nvim_get_current_win()
-    local key = string.format('%d_%s_%s_%d', winid, bar_type, side, idx)
-    return item_highlight_mappings[key]
-end
-
-function M.get_item_highlight_group_name(item_name, bar_type, rendered_idx, side)
-    local strategy_name, group_name = strategies.get_highlight_strategy(item_name, side, rendered_idx, bar_type)
-    
-    if strategy_name and group_name then
-        M.ensure_highlight_exists(strategy_name, group_name, side, rendered_idx, bar_type, item_name)
-        return group_name
-    end
-    
-    return nil
-end
-
 function M.extract_highlight_group(formatted_text)
-    -- Extract highlight group name from formatted text like '%#GroupName#text'
-    local group_name = formatted_text:match('%%#([^#]+)#')
-    return group_name
+    return formatted_text:match('%%#([^#]+)#')
 end
 
 function M.separator_direct(separator, side, current_hl_group, next_hl_group, bar_type)
     if not separator or separator == '' then
         return ''
     end
-    
+
     bar_type = bar_type or 'statusline'
-    local cache_key = string.format('%s_%s_%s_%s', bar_type, side, 
-                                    current_hl_group or 'default', 
-                                    next_hl_group or 'default')
-    
+    local cache_key = string.format('%s_%s_%s_%s', bar_type, side,
+        current_hl_group or 'default',
+        next_hl_group or 'default')
+
     if separator_cache[cache_key] then
         return separator_cache[cache_key]
     end
-    
+
     local sep_info = strategies.create_separator_highlight(separator, side, current_hl_group, next_hl_group, bar_type)
     active_groups[sep_info.group_name] = true
-    
+
     separator_cache[cache_key] = sep_info.formatted
     return sep_info.formatted
 end
 
 function M.clear_cache()
     separator_cache = {}
-    item_highlight_mappings = {}
     events.emit('highlight_cache_cleared')
 end
 
@@ -148,20 +88,8 @@ function M.clear_highlights()
     events.emit('highlights_cleared')
 end
 
-function M.refresh_all()
-    local old_groups = vim.tbl_keys(active_groups)
-    M.clear_highlights()
-    
-    events.emit('highlights_refreshed', { 
-        cleared_count = #old_groups 
-    })
-end
-
 function M.get_active_groups()
     return vim.tbl_keys(active_groups)
 end
-
--- Delegate to strategies module
-M.adjust_color = strategies.adjust_color
 
 return M

--- a/lua/luxline/rendering/highlight_strategies.lua
+++ b/lua/luxline/rendering/highlight_strategies.lua
@@ -1,23 +1,24 @@
 local M = {}
 
+local color = require('luxline.primitives.color')
 
--- Highlight strategy interface
+local DEFAULT_SEPARATOR_BG = '#1A1B26'
+
 local highlight_strategies = {}
 
--- Semantic highlight strategy
 highlight_strategies.semantic = {
     get_group_name = function(item_name, bar_type)
         if not item_name then return nil end
         local prefix = bar_type == 'winbar' and 'LuxlineWinbar' or 'Luxline'
         return prefix .. item_name:gsub('^%l', string.upper):gsub('_(%l)', string.upper)
     end,
-    
+
     is_available = function(group_name)
         local themes = require('luxline.themes')
         local theme = themes.get_current_theme()
         return theme and theme.semantic and theme.semantic[group_name] ~= nil
     end,
-    
+
     create_highlight = function(group_name, bar_type)
         local themes = require('luxline.themes')
         local theme = themes.get_current_theme()
@@ -31,7 +32,7 @@ highlight_strategies.semantic = {
         local bg = semantic_def.bg or (theme.gradient[4] and theme.gradient[4].bg) or '#808080'
 
         if bar_type == 'winbar' then
-            bg = M.adjust_color(bg, -10)
+            bg = color.adjust(bg, -10)
         end
 
         return {
@@ -44,18 +45,17 @@ highlight_strategies.semantic = {
     end
 }
 
--- Positional highlight strategy
 highlight_strategies.positional = {
     get_group_name = function(side, idx, bar_type)
         if not side or not idx then return nil end
         local prefix = bar_type == 'winbar' and 'LuxlineWinbar' or 'Luxline'
         return prefix .. 'Item' .. side:gsub('^%l', string.upper) .. idx
     end,
-    
-    is_available = function() 
-        return true -- Always available as fallback
+
+    is_available = function()
+        return true
     end,
-    
+
     create_highlight = function(group_name, side, idx, bar_type)
         local themes = require('luxline.themes')
         local theme = themes.get_current_theme()
@@ -75,7 +75,7 @@ highlight_strategies.positional = {
         local fg = entry.fg or '#d0d0d0'
 
         if bar_type == 'winbar' then
-            bg = M.adjust_color(bg, -10)
+            bg = color.adjust(bg, -10)
         end
 
         return {
@@ -85,22 +85,19 @@ highlight_strategies.positional = {
     end
 }
 
--- Strategy selector
 function M.get_highlight_strategy(item_name, side, idx, bar_type)
-    -- Try semantic first
     if item_name then
         local semantic_group = highlight_strategies.semantic.get_group_name(item_name, bar_type)
         if semantic_group and highlight_strategies.semantic.is_available(semantic_group) then
             return 'semantic', semantic_group
         end
     end
-    
-    -- Fallback to positional
+
     if side and idx then
         local positional_group = highlight_strategies.positional.get_group_name(side, idx, bar_type)
         return 'positional', positional_group
     end
-    
+
     return nil, nil
 end
 
@@ -109,47 +106,24 @@ function M.create_highlight_group(strategy_name, group_name, ...)
     if not strategy then
         return nil
     end
-    
+
     return strategy.create_highlight(group_name, ...)
 end
 
-function M.adjust_color(color, amount)
-    if not color or not color:match('^#') then
-        return color
-    end
-    
-    local r = tonumber(color:sub(2, 3), 16)
-    local g = tonumber(color:sub(4, 5), 16)
-    local b = tonumber(color:sub(6, 7), 16)
-    
-    r = math.max(0, math.min(255, r + amount))
-    g = math.max(0, math.min(255, g + amount))
-    b = math.max(0, math.min(255, b + amount))
-    
-    return string.format('#%02x%02x%02x', r, g, b)
-end
-
--- Unified separator creation
 function M.create_separator_highlight(separator, side, current_hl_group, next_hl_group, bar_type)
-    if not separator or separator == '' then
-        return ''
-    end
-    
-    local default_bg = '1A1B26'
-    local winid = vim.api.nvim_get_current_win()
     local prefix = bar_type == 'winbar' and 'LuxlineWinbarSep' or 'LuxlineSeparator'
     local current_name = current_hl_group or 'default'
     local next_name = next_hl_group or 'default'
     local cache_key = string.format('%s_%s_%s_%s', bar_type, side, current_name, next_name)
-    local hl_name = prefix .. winid .. '_' .. cache_key
-    
-    -- Get background colors from the actual highlight groups
-    local get_bg = function(hl_group)
-        if not hl_group then return default_bg end
-        local hl = vim.api.nvim_get_hl(0, { name = hl_group })
-        return hl.bg and string.format('%06x', hl.bg) or default_bg
+    local hl_name = prefix .. '_' .. cache_key
+
+    local function get_bg(hl_group)
+        if not hl_group then
+            return DEFAULT_SEPARATOR_BG
+        end
+        return color.from_highlight(hl_group).bg or DEFAULT_SEPARATOR_BG
     end
-    
+
     local fg_bg, bg_bg
     if side == 'right' then
         fg_bg = get_bg(next_hl_group)
@@ -158,16 +132,16 @@ function M.create_separator_highlight(separator, side, current_hl_group, next_hl
         fg_bg = get_bg(current_hl_group)
         bg_bg = get_bg(next_hl_group)
     end
-    
+
     vim.api.nvim_set_hl(0, hl_name, {
-        fg = '#' .. fg_bg,
-        bg = '#' .. bg_bg,
+        fg = fg_bg,
+        bg = bg_bg,
     })
-    
+
     return {
         group_name = hl_name,
         formatted = '%#' .. hl_name .. '#' .. separator,
-        cache_key = cache_key
+        cache_key = cache_key,
     }
 end
 

--- a/tests/spec/rendering_bar_builder_spec.lua
+++ b/tests/spec/rendering_bar_builder_spec.lua
@@ -1,0 +1,81 @@
+local assert = dofile(vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h') .. '/helpers/assert.lua')
+
+local function fixture_theme()
+    local themes = require('luxline.themes')
+    themes.register('bar-spec-theme', {
+        gradient = {
+            { bg = '#101010', fg = '#ffffff' }, { bg = '#202020', fg = '#ffffff' },
+            { bg = '#303030', fg = '#ffffff' }, { bg = '#404040', fg = '#ffffff' },
+            { bg = '#505050', fg = '#ffffff' }, { bg = '#606060', fg = '#ffffff' },
+            { bg = '#707070', fg = '#ffffff' },
+        },
+        middle = '#202020',
+    })
+    themes.set_theme('bar-spec-theme')
+end
+
+describe('rendering.bar_builder', function()
+    it('builds the golden statusline string for two fixed items', function()
+        require('luxline').setup({ git_enabled = false })
+        local items = require('luxline.items')
+        items.register('bar_spec_alpha', function() return 'A' end, {})
+        items.register('bar_spec_beta', function() return 'B' end, {})
+        require('luxline.config').setup({
+            left_active_items = { 'bar_spec_alpha', 'bar_spec_beta' },
+            right_active_items = {},
+            left_separator = '>',
+            right_separator = '<',
+        })
+        fixture_theme()
+        local bar_builder = require('luxline.rendering.bar_builder')
+        local ctx = require('luxline.core.context').get_current_context()
+        ctx.active = true
+        local rendered = bar_builder.build_for_context(ctx, 'statusline')
+        local expected = '%#LuxlineItemLeft1# A '
+            .. '%#LuxlineSeparator_statusline_left_LuxlineItemLeft1_LuxlineItemLeft2#>'
+            .. '%#LuxlineItemLeft2# B '
+            .. '%#LuxlineSeparator_statusline_left_LuxlineItemLeft2_default#>'
+            .. '%='
+        assert.eq(rendered, expected)
+    end)
+
+    it('skips winbar rendering for disabled filetypes', function()
+        require('luxline').setup({ git_enabled = false, winbar_disabled_filetypes = { 'spectype' } })
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_set_current_buf(buf)
+        vim.api.nvim_set_option_value('filetype', 'spectype', { buf = buf })
+        vim.api.nvim_set_option_value('winbar', '', { win = 0 })
+        require('luxline.rendering.bar_builder').winbar.update_all()
+        assert.eq(vim.api.nvim_get_option_value('winbar', { win = 0 }), '')
+    end)
+
+    it('exposes generated statusline and winbar sub-APIs without update_window', function()
+        local bar_builder = require('luxline.rendering.bar_builder')
+        for _, bar_type in ipairs({ 'statusline', 'winbar' }) do
+            assert.truthy(bar_builder[bar_type].build_for_context)
+            assert.truthy(bar_builder[bar_type].build_section)
+            assert.truthy(bar_builder[bar_type].update_all)
+            assert.truthy(bar_builder[bar_type].preview)
+            assert.eq(bar_builder[bar_type].update_window, nil, 'single-window public surface is removed')
+        end
+        assert.eq(bar_builder.update_window, nil)
+    end)
+
+    it('drops empty items and keeps rendered positions sequential', function()
+        require('luxline').setup({ git_enabled = false })
+        local items = require('luxline.items')
+        items.register('bar_spec_empty', function() return '' end, {})
+        items.register('bar_spec_solid', function() return 'S' end, {})
+        require('luxline.config').setup({
+            left_active_items = { 'bar_spec_empty', 'bar_spec_solid' },
+            right_active_items = {},
+            left_separator = '',
+        })
+        fixture_theme()
+        local bar_builder = require('luxline.rendering.bar_builder')
+        local ctx = require('luxline.core.context').get_current_context()
+        ctx.active = true
+        local rendered = bar_builder.build_for_context(ctx, 'statusline')
+        assert.eq(rendered, '%#LuxlineItemLeft1# S %=', 'empty item dropped; solid item takes rendered position 1')
+    end)
+end)

--- a/tests/spec/rendering_highlight_spec.lua
+++ b/tests/spec/rendering_highlight_spec.lua
@@ -1,0 +1,77 @@
+local assert = dofile(vim.fn.fnamemodify(debug.getinfo(1, 'S').source:sub(2), ':p:h:h') .. '/helpers/assert.lua')
+
+describe('rendering.highlight', function()
+    it('creates one separator group per color pair, without winid in the name', function()
+        require('luxline').setup({ git_enabled = false })
+        local highlight = require('luxline.rendering.highlight')
+        vim.api.nvim_set_hl(0, 'LuxSepSpecA', { bg = '#111111' })
+        vim.api.nvim_set_hl(0, 'LuxSepSpecB', { bg = '#222222' })
+
+        local formatted = highlight.separator_direct('>', 'left', 'LuxSepSpecA', 'LuxSepSpecB', 'statusline')
+        local group = formatted:match('%%#([^#]+)#')
+        assert.eq(group, 'LuxlineSeparator_statusline_left_LuxSepSpecA_LuxSepSpecB')
+
+        local hl = vim.api.nvim_get_hl(0, { name = group })
+        assert.eq(string.format('#%06x', hl.fg), '#111111', 'left separator fg = current item bg')
+        assert.eq(string.format('#%06x', hl.bg), '#222222', 'left separator bg = next item bg')
+    end)
+
+    it('right-side separators swap the blend direction', function()
+        local highlight = require('luxline.rendering.highlight')
+        vim.api.nvim_set_hl(0, 'LuxSepSpecC', { bg = '#333333' })
+        vim.api.nvim_set_hl(0, 'LuxSepSpecD', { bg = '#444444' })
+        local formatted = highlight.separator_direct('<', 'right', 'LuxSepSpecC', 'LuxSepSpecD', 'statusline')
+        local group = formatted:match('%%#([^#]+)#')
+        local hl = vim.api.nvim_get_hl(0, { name = group })
+        assert.eq(string.format('#%06x', hl.fg), '#444444', 'right separator fg = next item bg')
+        assert.eq(string.format('#%06x', hl.bg), '#333333', 'right separator bg = current item bg')
+    end)
+
+    it('falls back to the default separator bg for missing groups', function()
+        local highlight = require('luxline.rendering.highlight')
+        local formatted = highlight.separator_direct('>', 'left', nil, nil, 'statusline')
+        local group = formatted:match('%%#([^#]+)#')
+        local hl = vim.api.nvim_get_hl(0, { name = group })
+        assert.eq(string.format('#%06x', hl.fg), '#1a1b26')
+        assert.eq(string.format('#%06x', hl.bg), '#1a1b26')
+    end)
+
+    it('returns empty string for an empty separator', function()
+        local highlight = require('luxline.rendering.highlight')
+        assert.eq(highlight.separator_direct('', 'left', 'A', 'B', 'statusline'), '')
+        assert.eq(highlight.separator_direct(nil, 'left', 'A', 'B', 'statusline'), '')
+    end)
+
+    it('removes the dead highlight surface', function()
+        local highlight = require('luxline.rendering.highlight')
+        assert.eq(highlight.get_highlight_value, nil)
+        assert.eq(highlight.get_item_highlight_group, nil)
+        assert.eq(highlight.get_item_highlight_group_name, nil)
+        assert.eq(highlight.create_highlight, nil)
+        assert.eq(highlight.refresh_all, nil)
+        assert.eq(highlight.store_item_highlight_mapping, nil)
+        assert.eq(highlight.adjust_color, nil)
+    end)
+
+    it('selects semantic strategy when the theme defines the group, positional otherwise', function()
+        local strategies = require('luxline.rendering.highlight_strategies')
+        local themes = require('luxline.themes')
+        themes.register('hl-spec-theme', {
+            gradient = {
+                { bg = '#101010', fg = '#ffffff' }, { bg = '#202020', fg = '#ffffff' },
+                { bg = '#303030', fg = '#ffffff' }, { bg = '#404040', fg = '#ffffff' },
+                { bg = '#505050', fg = '#ffffff' }, { bg = '#606060', fg = '#ffffff' },
+                { bg = '#707070', fg = '#ffffff' },
+            },
+            middle = '#202020',
+            semantic = { LuxlineFilename = { bg = '#aabbcc', fg = '#000000' } },
+        })
+        themes.set_theme('hl-spec-theme')
+        local strategy, group = strategies.get_highlight_strategy('filename', 'left', 1, 'statusline')
+        assert.eq(strategy, 'semantic')
+        assert.eq(group, 'LuxlineFilename')
+        strategy, group = strategies.get_highlight_strategy('position', 'left', 2, 'statusline')
+        assert.eq(strategy, 'positional')
+        assert.eq(group, 'LuxlineItemLeft2')
+    end)
+end)


### PR DESCRIPTION
Phase 5 of the primitive-first refactor: highlight_strategies delegates color math to the color primitive and the separator path owns its #1A1B26 fallback; separator highlight groups drop the winid component (one group per color pair instead of per window — verified the render delta is confined to exactly that rename); highlight.lua sheds its dead surface (mapping store, shims, unused getters); bar_builder generates the statusline/winbar sub-APIs from a loop, shares one private per-window render, drops the dead public update_window, and replaces deprecated nvim_buf_get_option.

Gates verified: suite 56/56 passing, golden-string and separator specs green, baseline delta separator-names-only then re-captured and matching.